### PR TITLE
Give access to public poses to everyone

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,4 +3,16 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery
   before_action :authenticate_user!
+
+  def require_admin
+    return if current_user_admin?
+
+    sign_out current_user
+    redirect_to new_user_session_path, alert: 'Must be Admin to access this area'
+  end
+
+  def current_user_admin?
+    current_user&.admin?
+  end
+  helper_method :current_user_admin?
 end

--- a/app/controllers/playlists_controller.rb
+++ b/app/controllers/playlists_controller.rb
@@ -20,6 +20,7 @@ class PlaylistsController < ApplicationController
   end
 
   def edit
+    @playlist.playlist_poses.order(:sequence_number)
     3.times { @playlist.playlist_poses.build }
   end
 

--- a/app/controllers/playlists_controller.rb
+++ b/app/controllers/playlists_controller.rb
@@ -12,7 +12,11 @@ class PlaylistsController < ApplicationController
 
   def new
     @playlist = current_user.playlists.new
-    15.times { @playlist.playlist_poses.build }
+    i = 1
+    15.times do
+      @playlist.playlist_poses.build(sequence_number: i)
+      i += 1
+    end
   end
 
   def edit
@@ -21,6 +25,7 @@ class PlaylistsController < ApplicationController
 
   def create
     @playlist = current_user.playlists.new(playlist_params)
+    @playlist.playlist_poses = @playlist.playlist_poses.reject {|pose| pose.pose_id == nil }
 
     if @playlist.save
       redirect_to @playlist, notice: 'Playlist was successfully created.'

--- a/app/controllers/playlists_controller.rb
+++ b/app/controllers/playlists_controller.rb
@@ -26,7 +26,7 @@ class PlaylistsController < ApplicationController
 
   def create
     @playlist = current_user.playlists.new(playlist_params)
-    @playlist.playlist_poses = @playlist.playlist_poses.reject {|pose| pose.pose_id == nil }
+    @playlist.playlist_poses = @playlist.playlist_poses.reject { |pose| pose.pose_id.nil? }
 
     if @playlist.save
       redirect_to @playlist, notice: 'Playlist was successfully created.'

--- a/app/controllers/poses_controller.rb
+++ b/app/controllers/poses_controller.rb
@@ -5,7 +5,7 @@ class PosesController < ApplicationController
   before_action :require_admin
 
   def index
-    @poses = current_user.poses.all.order(:name)
+    @poses = current_user.poses.by_name
   end
 
   def show

--- a/app/controllers/poses_controller.rb
+++ b/app/controllers/poses_controller.rb
@@ -21,7 +21,7 @@ class PosesController < ApplicationController
     @pose = current_user.poses.new(pose_params)
 
     if @pose.save
-      redirect_to @pose, notice: 'Pose was successfully created.'
+      redirect_to poses_url, notice: 'Pose was successfully created.'
     else
       render :new
     end
@@ -29,7 +29,7 @@ class PosesController < ApplicationController
 
   def update
     if @pose.update(pose_params)
-      redirect_to @pose, notice: 'Pose was successfully updated.'
+      redirect_to poses_url, notice: 'Pose was successfully updated.'
     else
       render :edit
     end

--- a/app/controllers/poses_controller.rb
+++ b/app/controllers/poses_controller.rb
@@ -48,6 +48,6 @@ class PosesController < ApplicationController
   end
 
   def pose_params
-    params.require(:pose).permit(:name, :audio_file, :image_file, :user_id)
+    params.require(:pose).permit(:name, :audio_file, :image_file, :user_id, :admin_only)
   end
 end

--- a/app/controllers/poses_controller.rb
+++ b/app/controllers/poses_controller.rb
@@ -2,6 +2,7 @@
 
 class PosesController < ApplicationController
   before_action :set_pose, only: %i[show edit update destroy]
+  before_action :require_admin
 
   def index
     @poses = current_user.poses.all.order(:name)

--- a/app/helpers/poses_helper.rb
+++ b/app/helpers/poses_helper.rb
@@ -2,6 +2,6 @@
 
 module PosesHelper
   def form_poses(user)
-    user.admin? ? Pose.by_name : Pose.public.by_name
+    user.admin? ? Pose.by_name : Pose.public_poses.by_name
   end
 end

--- a/app/helpers/poses_helper.rb
+++ b/app/helpers/poses_helper.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module PosesHelper
+  def form_poses(user)
+    user.admin? ? Pose.by_name : Pose.public.by_name
+  end
+end

--- a/app/models/pose.rb
+++ b/app/models/pose.rb
@@ -9,4 +9,7 @@ class Pose < ApplicationRecord
             :audio_file,
             :image_file,
             presence: true
+  def self.public
+    where(private: false)
+  end
 end

--- a/app/models/pose.rb
+++ b/app/models/pose.rb
@@ -9,6 +9,9 @@ class Pose < ApplicationRecord
             :audio_file,
             :image_file,
             presence: true
+
+  scope :by_name, -> { order(name: 'ASC') }
+
   def self.public
     where(private: false)
   end

--- a/app/models/pose.rb
+++ b/app/models/pose.rb
@@ -11,8 +11,5 @@ class Pose < ApplicationRecord
             presence: true
 
   scope :by_name, -> { order(name: 'ASC') }
-
-  def self.public
-    where(private: false)
-  end
+  scope :public_poses, -> { where(admin_only: false) }
 end

--- a/app/views/playlist_poses/_form_fields.html.erb
+++ b/app/views/playlist_poses/_form_fields.html.erb
@@ -1,6 +1,6 @@
 <td><%= f_playlist_pose.text_field :sequence_number, class: 'form-control input--small' %></td>
 <td>
-  <%= f_playlist_pose.collection_select :pose_id, Pose.public.by_name, :id, :name, { prompt: "-- Select a Pose --" }, class: 'form-control' %>
+  <%= f_playlist_pose.collection_select :pose_id, form_poses(current_user), :id, :name, { prompt: "-- Select a Pose --" }, class: 'form-control' %>
 </td>
 
 <td><%= f_playlist_pose.check_box :_destroy if f_playlist_pose.object.persisted? %></td>

--- a/app/views/playlist_poses/_form_fields.html.erb
+++ b/app/views/playlist_poses/_form_fields.html.erb
@@ -1,6 +1,6 @@
 <td><%= f_playlist_pose.text_field :sequence_number, class: 'form-control input--small' %></td>
 <td>
-  <%= f_playlist_pose.collection_select :pose_id, current_user.poses.all, :id, :name, { prompt: "-- Select a Pose --" }, class: 'form-control' %>
+  <%= f_playlist_pose.collection_select :pose_id, Pose.public.by_name, :id, :name, { prompt: "-- Select a Pose --" }, class: 'form-control' %>
 </td>
 
 <td><%= f_playlist_pose.check_box :_destroy if f_playlist_pose.object.persisted? %></td>

--- a/app/views/playlists/_form.html.erb
+++ b/app/views/playlists/_form.html.erb
@@ -14,9 +14,9 @@
   <table class="table table-playlist_poses">
     <thead>
       <tr>
-        <th>Sequence Number</th>
+        <th width="10%">Sequence Number</th>
         <th>Pose</th>
-        <th>Delete?</th>
+        <th width="10%">Delete?</th>
       </tr>
     </thead>
     <tbody>

--- a/app/views/playlists/new.html.erb
+++ b/app/views/playlists/new.html.erb
@@ -1,5 +1,6 @@
-<h1>New Playlist</h1>
+<h1>
+  <%= link_to 'Back', playlists_path, class: 'btn btn-sm btn-secondary right' %>
+  New Playlist
+</h1>
 
 <%= render 'form', playlist: @playlist %>
-
-<%= link_to 'Back', playlists_path %>

--- a/app/views/poses/_form.html.erb
+++ b/app/views/poses/_form.html.erb
@@ -22,6 +22,13 @@
     </div>
   </div>
 
+  <div class='form-group row'>
+    <%= form.label :admin_only, class: 'col-sm-2 col-form-label'  %>
+    <div class='col-sm-10'>
+      <%= form.check_box :admin_only, class: 'form-control' %>
+    </div>
+  </div>
+
   <div class='actions mt-3'>
     <%= form.submit class: 'btn btn-sm btn-primary'%>
   </div>

--- a/app/views/poses/new.html.erb
+++ b/app/views/poses/new.html.erb
@@ -1,5 +1,6 @@
-<h1>New Pose</h1>
+<h1>
+  <%= link_to 'Cancel', poses_path, class: 'btn btn-sm btn-secondary right' %>
+  New Pose
+</h1>
 
 <%= render 'form', pose: @pose %>
-
-<%= link_to 'Back', poses_path %>

--- a/app/views/shared/_session_nav.html.erb
+++ b/app/views/shared/_session_nav.html.erb
@@ -1,6 +1,7 @@
 <li class='nav-item'><%= link_to 'Playlists', playlists_path, class: 'nav-link' %></li>
-<li class='nav-item'><%= link_to 'Poses', poses_path, class: 'nav-link' %></li>
-
+<% if current_user_admin? %>
+  <li class='nav-item'><%= link_to 'Poses', poses_path, class: 'nav-link' %></li>
+<% end %>
 
 <li class='nav-item dropdown'>
   <a class='nav-link dropdown-toggle' href='#' id='navbarDropdown' role='button' data-toggle='dropdown' aria-haspopup='true' aria-expanded='false'>

--- a/db/migrate/20191005202201_add_private_to_poses.rb
+++ b/db/migrate/20191005202201_add_private_to_poses.rb
@@ -1,0 +1,5 @@
+class AddPrivateToPoses < ActiveRecord::Migration[6.0]
+  def change
+    add_column :poses, :private, :boolean, default: false
+  end
+end

--- a/db/migrate/20191005202201_add_private_to_poses.rb
+++ b/db/migrate/20191005202201_add_private_to_poses.rb
@@ -1,5 +1,5 @@
 class AddPrivateToPoses < ActiveRecord::Migration[6.0]
   def change
-    add_column :poses, :private, :boolean, default: false
+    add_column :poses, :admin_only, :boolean, default: false
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -41,7 +41,7 @@ ActiveRecord::Schema.define(version: 2019_10_05_202201) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "user_id"
-    t.boolean "private", default: false
+    t.boolean "admin_only", default: false
     t.index ["user_id"], name: "index_poses_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_10_230805) do
+ActiveRecord::Schema.define(version: 2019_10_05_202201) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -41,6 +41,7 @@ ActiveRecord::Schema.define(version: 2019_09_10_230805) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "user_id"
+    t.boolean "private", default: false
     t.index ["user_id"], name: "index_poses_on_user_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,88 +1,88 @@
 # frozen_string_literal: true
 
 puts 'Destroy AllTheThings!'
-User.destroy_all
-PlaylistPose.destroy_all
-Pose.destroy_all
-Playlist.destroy_all
+# User.destroy_all
+# PlaylistPose.destroy_all
+# Pose.destroy_all
+# Playlist.destroy_all
 
-user = User.create!(email: 'admin@email.com', admin: true, password: 'password', password_confirmation: 'password')
+user = User.find_or_create_by(email: 'admin@email.com') do |user|
+  user.admin = true,
+  user.password = 'password',
+  user.password_confirmation = 'password'
+end
 
 puts 'Create Number Poses'
-one = user.poses.create!(name: 'one', audio_file: '1.wav', image_file: '1.jpg')
-two = user.poses.create!(name: 'two', audio_file: '2.wav', image_file: '2.jpg')
-three = user.poses.create!(name: 'three', audio_file: '3.wav', image_file: '3.jpg')
-four = user.poses.create!(name: 'four', audio_file: '4.wav', image_file: '4.jpg')
-five = user.poses.create!(name: 'five', audio_file: '5.wav', image_file: '5.jpg')
+one = user.poses.find_or_create_by(audio_file: '1.wav') { |pose| pose.name = 'one'; pose.image_file = '1.jpg' }
+two = user.poses.find_or_create_by(audio_file: '2.wav') { |pose| pose.name = 'two'; pose.image_file = '2.jpg' }
+three = user.poses.find_or_create_by(audio_file: '3.wav') { |pose| pose.name = 'three'; pose.image_file = '3.jpg' }
+four = user.poses.find_or_create_by(audio_file: '4.wav') { |pose| pose.name = 'four'; pose.image_file = '4.jpg' }
+five = user.poses.find_or_create_by(audio_file: '5.wav') { |pose| pose.name = 'five'; pose.image_file = '5.jpg' }
 
 puts 'Create Numbers Playlists'
-playlist = user.playlists.create!(name: 'one two one', hold_time: 3)
-playlist.playlist_poses.create!([
-  { sequence_number: 1, pose_id: one.id },
-  { sequence_number: 2, pose_id: two.id },
-  { sequence_number: 3, pose_id: one.id },
-])
+playlist = user.playlists.find_or_create_by(name: 'one two one') { |pose| pose.hold_time = 3 }
+  playlist.playlist_poses.find_or_create_by(sequence_number: 1, pose_id: one.id)
+  playlist.playlist_poses.find_or_create_by(sequence_number: 2, pose_id: two.id)
+  playlist.playlist_poses.find_or_create_by(sequence_number: 3, pose_id: one.id)
 
-playlist = user.playlists.create!(name: 'one two three four five', hold_time: 3)
-playlist.playlist_poses.create!([
-  { sequence_number: 1, pose_id: one.id },
-  { sequence_number: 2, pose_id: two.id },
-  { sequence_number: 3, pose_id: three.id },
-  { sequence_number: 4, pose_id: four.id },
-  { sequence_number: 5, pose_id: five.id },
-])
+playlist = user.playlists.find_or_create_by(name: 'one two three four five') { |pose| pose.hold_time = 3 }
+  playlist.playlist_poses.find_or_create_by(sequence_number: 1, pose_id: one.id)
+  playlist.playlist_poses.find_or_create_by(sequence_number: 2, pose_id: two.id)
+  playlist.playlist_poses.find_or_create_by(sequence_number: 3, pose_id: three.id)
+  playlist.playlist_poses.find_or_create_by(sequence_number: 4, pose_id: four.id)
+  playlist.playlist_poses.find_or_create_by(sequence_number: 5, pose_id: five.id)
 
 puts 'Create Yoga Poses'
-begin_at_head_of_yoga_mat = user.poses.create!(name: 'begin_at_head_of_yoga_mat', audio_file: 'begin_at_head_of_yoga_mat.m4a', image_file: 'standing_straight.png')
-tree = user.poses.create!(name: 'tree', audio_file: 'tree.m4a', image_file: 'tree.png')
-dive_down_to_standing_fwd_bend = user.poses.create!(name: 'dive_down_to_standing_fwd_bend', audio_file: 'dive_down_to_standing_fwd_bend.m4a', image_file: 'standing_forward_bend.png')
-raise_up_to_flat_back = user.poses.create!(name: 'raise_up_to_flat_back', audio_file: 'raise_up_to_flat_back.m4a', image_file: 'flat_back.png')
-back_down_to_standing_fwd_bend = user.poses.create!(name: 'back_down_to_standing_fwd_bend', audio_file: 'back_down_to_standing_fwd_bend.m4a', image_file: 'standing_forward_bend.png')
-jump_back_to_plank = user.poses.create!(name: 'jump_back_to_plank', audio_file: 'jump_back_to_plank.m4a', image_file: 'plank.png')
-slowly_lower_to_chaturanga = user.poses.create!(name: 'slowly_lower_to_chaturanga', audio_file: 'slowly_lower_to_chaturanga.m4a', image_file: 'chaturanga.png')
-down_to_floor_up_to_cobra = user.poses.create!(name: 'down_to_floor_up_to_cobra', audio_file: 'down_to_floor_up_to_cobra.m4a', image_file: 'cobra.png')
-push_back_downward_dog_right_leg = user.poses.create!(name: 'push_back_downward_dog_right_leg', audio_file: 'push_back_downward_dog_right_leg.m4a', image_file: 'downward_dog_right_leg.png')
-push_back_downward_dog_left_leg = user.poses.create!(name: 'push_back_downward_dog_left_leg', audio_file: 'push_back_downward_dog_left_leg.m4a', image_file: 'downward_dog_left_leg.png')
+begin_at_head_of_yoga_mat = user.poses.find_or_create_by(audio_file: 'begin_at_head_of_yoga_mat.m4a') { |pose| pose.name = 'begin_at_head_of_yoga_mat'; pose.image_file = 'standing_straight.png' }
+tree = user.poses.find_or_create_by(audio_file: 'tree.m4a') { |pose| pose.name = 'tree'; pose.image_file = 'tree.png' }
+dive_down_to_standing_fwd_bend = user.poses.find_or_create_by(audio_file: 'dive_down_to_standing_fwd_bend.m4a') { |pose| pose.name = 'dive_down_to_standing_fwd_bend'; pose.image_file = 'standing_forward_bend.png' }
+raise_up_to_flat_back = user.poses.find_or_create_by(audio_file: 'raise_up_to_flat_back.m4a') { |pose| pose.name = 'raise_up_to_flat_back'; pose.image_file = 'flat_back.png' }
+back_down_to_standing_fwd_bend = user.poses.find_or_create_by(audio_file: 'back_down_to_standing_fwd_bend.m4a') { |pose| pose.name = 'back_down_to_standing_fwd_bend'; pose.image_file = 'standing_forward_bend.png' }
+jump_back_to_plank = user.poses.find_or_create_by(audio_file: 'jump_back_to_plank.m4a') { |pose| pose.name = 'jump_back_to_plank'; pose.image_file = 'plank.png' }
+slowly_lower_to_chaturanga = user.poses.find_or_create_by(audio_file: 'slowly_lower_to_chaturanga.m4a') { |pose| pose.name = 'slowly_lower_to_chaturanga'; pose.image_file = 'chaturanga.png' }
+down_to_floor_up_to_cobra = user.poses.find_or_create_by(audio_file: 'down_to_floor_up_to_cobra.m4a') { |pose| pose.name = 'down_to_floor_up_to_cobra'; pose.image_file = 'cobra.png' }
+push_back_downward_dog_right_leg = user.poses.find_or_create_by(audio_file: 'push_back_downward_dog_right_leg.m4a') { |pose| pose.name = 'push_back_downward_dog_right_leg'; pose.image_file = 'downward_dog_right_leg.png' }
+push_back_downward_dog_left_leg = user.poses.find_or_create_by(audio_file: 'push_back_downward_dog_left_leg.m4a') { |pose| pose.name = 'push_back_downward_dog_left_leg'; pose.image_file = 'downward_dog_left_leg.png' }
 
-swing_right_leg_runners_pose = user.poses.create!(name: 'swing_right_leg_runners_pose', audio_file: 'swing_right_leg_runners_pose.m4a', image_file: 'runners_pose.png')
-swing_left_leg_runners_pose = user.poses.create!(name: 'swing_left_leg_runners_pose', audio_file: 'swing_left_leg_runners_pose.m4a', image_file: 'runners_pose.png')
+swing_right_leg_runners_pose = user.poses.find_or_create_by(audio_file: 'swing_right_leg_runners_pose.m4a') { |pose| pose.name = 'swing_right_leg_runners_pose'; pose.image_file = 'runners_pose.png' }
+swing_left_leg_runners_pose = user.poses.find_or_create_by(audio_file: 'swing_left_leg_runners_pose.m4a') { |pose| pose.name = 'swing_left_leg_runners_pose'; pose.image_file = 'runners_pose.png' }
 
-arms_above_head_for_crescent_pose = user.poses.create!(name: 'arms_above_head_for_crescent_pose', audio_file: 'arms_above_head_for_crescent_pose.m4a', image_file: 'crescent_pose.png')
-swing_arm_back_warrior_2 = user.poses.create!(name: 'swing_arm_back_warrior_2', audio_file: 'swing_arm_back_warrior_2.m4a', image_file: 'warrior2.png')
-lean_back_into_reverse_warrior = user.poses.create!(name: 'lean_back_into_reverse_warrior', audio_file: 'lean_back_into_reverse_warrior.m4a', image_file: 'reverse_warrior.png')
-straighten_for_standing_reverse_warrior = user.poses.create!(name: 'straighten_for_standing_reverse_warrior', audio_file: 'straighten_for_standing_reverse_warrior.m4a', image_file: 'standing_reverse_warrior.png')
+arms_above_head_for_crescent_pose = user.poses.find_or_create_by(audio_file: 'arms_above_head_for_crescent_pose.m4a') { |pose| pose.name = 'arms_above_head_for_crescent_pose'; pose.image_file = 'crescent_pose.png' }
+swing_arm_back_warrior_2 = user.poses.find_or_create_by(audio_file: 'swing_arm_back_warrior_2.m4a') { |pose| pose.name = 'swing_arm_back_warrior_2'; pose.image_file = 'warrior2.png' }
+lean_back_into_reverse_warrior = user.poses.find_or_create_by(audio_file: 'lean_back_into_reverse_warrior.m4a') { |pose| pose.name = 'lean_back_into_reverse_warrior'; pose.image_file = 'reverse_warrior.png' }
+straighten_for_standing_reverse_warrior = user.poses.find_or_create_by(audio_file: 'straighten_for_standing_reverse_warrior.m4a') { |pose| pose.name = 'straighten_for_standing_reverse_warrior'; pose.image_file = 'standing_reverse_warrior.png' }
 
-triangle_pose_left_arm_up = user.poses.create!(name: 'triangle_pose_left_arm_up', audio_file: 'triangle_pose_left_arm_up.m4a', image_file: 'triangle_pose_left_arm_up.png')
-triangle_pose_right_arm_up = user.poses.create!(name: 'triangle_pose_right_arm_up', audio_file: 'triangle_pose_right_arm_up.m4a', image_file: 'triangle_pose_right_arm_up.png')
+triangle_pose_left_arm_up = user.poses.find_or_create_by(audio_file: 'triangle_pose_left_arm_up.m4a') { |pose| pose.name = 'triangle_pose_left_arm_up'; pose.image_file = 'triangle_pose_left_arm_up.png' }
+triangle_pose_right_arm_up = user.poses.find_or_create_by(audio_file: 'triangle_pose_right_arm_up.m4a') { |pose| pose.name = 'triangle_pose_right_arm_up'; pose.image_file = 'triangle_pose_right_arm_up.png' }
 
-reverse_warrior = user.poses.create!(name: 'reverse_warrior', audio_file: 'reverse_warrior.m4a', image_file: 'reverse_warrior.png')
-warrior2 = user.poses.create!(name: 'warrior2', audio_file: 'warrior2.m4a', image_file: 'warrior2.png')
-warrior1 = user.poses.create!(name: 'warrior1', audio_file: 'warrior1.m4a', image_file: 'warrior1.png')
-runners_pose = user.poses.create!(name: 'runners_pose', audio_file: 'runners_pose.m4a', image_file: 'runners_pose.png')
-collapse_into_pigeon = user.poses.create!(name: 'collapse_into_pigeon', audio_file: 'collapse_into_pigeon.m4a', image_file: 'pigeon.png')
+reverse_warrior = user.poses.find_or_create_by(audio_file: 'reverse_warrior.m4a') { |pose| pose.name = 'reverse_warrior'; pose.image_file = 'reverse_warrior.png' }
+warrior2 = user.poses.find_or_create_by(audio_file: 'warrior2.m4a') { |pose| pose.name = 'warrior2'; pose.image_file = 'warrior2.png' }
+warrior1 = user.poses.find_or_create_by(audio_file: 'warrior1.m4a') { |pose| pose.name = 'warrior1'; pose.image_file = 'warrior1.png' }
+runners_pose = user.poses.find_or_create_by(audio_file: 'runners_pose.m4a') { |pose| pose.name = 'runners_pose'; pose.image_file = 'runners_pose.png' }
+collapse_into_pigeon = user.poses.find_or_create_by(audio_file: 'collapse_into_pigeon.m4a') { |pose| pose.name = 'collapse_into_pigeon'; pose.image_file = 'pigeon.png' }
 
-swing_right_leg_up_to_one_leg_downward_dog = user.poses.create!(name: 'swing_right_leg_up_to_one_leg_downward_dog', audio_file: 'swing_right_leg_up_to_one_leg_downward_dog.m4a', image_file: 'downward_dog_right_leg.png')
-swing_left_leg_up_to_one_leg_downward_dog = user.poses.create!(name: 'swing_left_leg_up_to_one_leg_downward_dog', audio_file: 'swing_left_leg_up_to_one_leg_downward_dog.m4a', image_file: 'downward_dog_left_leg.png')
+swing_right_leg_up_to_one_leg_downward_dog = user.poses.find_or_create_by(audio_file: 'swing_right_leg_up_to_one_leg_downward_dog.m4a') { |pose| pose.name = 'swing_right_leg_up_to_one_leg_downward_dog'; pose.image_file = 'downward_dog_right_leg.png' }
+swing_left_leg_up_to_one_leg_downward_dog = user.poses.find_or_create_by(audio_file: 'swing_left_leg_up_to_one_leg_downward_dog.m4a') { |pose| pose.name = 'swing_left_leg_up_to_one_leg_downward_dog'; pose.image_file = 'downward_dog_left_leg.png' }
 
-leg_up_into_one_legged_chaturanga = user.poses.create!(name: 'leg_up_into_one_legged_chaturanga', audio_file: 'leg_up_into_one_legged_chaturanga.m4a', image_file: 'chaturanga.png')
-push_up_to_upward_dog = user.poses.create!(name: 'push_up_to_upward_dog', audio_file: 'push_up_to_upward_dog.m4a', image_file: 'upward_dog.png')
+leg_up_into_one_legged_chaturanga = user.poses.find_or_create_by(audio_file: 'leg_up_into_one_legged_chaturanga.m4a') { |pose| pose.name = 'leg_up_into_one_legged_chaturanga'; pose.image_file = 'chaturanga.png' }
+push_up_to_upward_dog = user.poses.find_or_create_by(audio_file: 'push_up_to_upward_dog.m4a') { |pose| pose.name = 'push_up_to_upward_dog'; pose.image_file = 'upward_dog.png' }
 
-side_plank_right_hand_down = user.poses.create!(name: 'side_plank_right_hand_down', audio_file: 'side_plank_right_hand_down.m4a', image_file: 'side_plank_right_hand_down.png')
-side_plank_left_hand_down = user.poses.create!(name: 'side_plank_left_hand_down', audio_file: 'side_plank_left_hand_down.m4a', image_file: 'side_plank_left_hand_down.png')
+side_plank_right_hand_down = user.poses.find_or_create_by(audio_file: 'side_plank_right_hand_down.m4a') { |pose| pose.name = 'side_plank_right_hand_down'; pose.image_file = 'side_plank_right_hand_down.png' }
+side_plank_left_hand_down = user.poses.find_or_create_by(audio_file: 'side_plank_left_hand_down.m4a') { |pose| pose.name = 'side_plank_left_hand_down'; pose.image_file = 'side_plank_left_hand_down.png' }
 
-down_to_downward_dog = user.poses.create!(name: 'down_to_downward_dog', audio_file: 'down_to_downward_dog.m4a', image_file: 'downward_dog.png')
-jump_up_to_standing_fwd_bend = user.poses.create!(name: 'jump_up_to_standing_fwd_bend', audio_file: 'jump_up_to_standing_fwd_bend.m4a', image_file: 'standing_forward_bend.png')
+down_to_downward_dog = user.poses.find_or_create_by(audio_file: 'down_to_downward_dog.m4a') { |pose| pose.name = 'down_to_downward_dog'; pose.image_file = 'downward_dog.png' }
+jump_up_to_standing_fwd_bend = user.poses.find_or_create_by(audio_file: 'jump_up_to_standing_fwd_bend.m4a') { |pose| pose.name = 'jump_up_to_standing_fwd_bend'; pose.image_file = 'standing_forward_bend.png' }
 
-half_moon_pose_standing_on_right = user.poses.create!(name: 'half_moon_pose_standing_on_right', audio_file: 'half_moon_pose_standing_on_right.m4a', image_file: 'half_moon_pose_standing_on_right.png')
-half_moon_pose_standing_on_left = user.poses.create!(name: 'half_moon_pose_standing_on_left', audio_file: 'half_moon_pose_standing_on_left.m4a', image_file: 'half_moon_pose_standing_on_left.png')
+half_moon_pose_standing_on_right = user.poses.find_or_create_by(audio_file: 'half_moon_pose_standing_on_right.m4a') { |pose| pose.name = 'half_moon_pose_standing_on_right'; pose.image_file = 'half_moon_pose_standing_on_right.png' }
+half_moon_pose_standing_on_left = user.poses.find_or_create_by(audio_file: 'half_moon_pose_standing_on_left.m4a') { |pose| pose.name = 'half_moon_pose_standing_on_left'; pose.image_file = 'half_moon_pose_standing_on_left.png' }
 
-come_back_down_to_standing_fwd_bend = user.poses.create!(name: 'come_back_down_to_standing_fwd_bend', audio_file: 'come_back_down_to_standing_fwd_bend.m4a', image_file: 'standing_forward_bend.png')
+come_back_down_to_standing_fwd_bend = user.poses.find_or_create_by(audio_file: 'come_back_down_to_standing_fwd_bend.m4a') { |pose| pose.name = 'come_back_down_to_standing_fwd_bend'; pose.image_file = 'standing_forward_bend.png' }
 
-one_leg_tree_on_right = user.poses.create!(name: 'one_leg_tree_on_right', audio_file: 'one_leg_tree_on_right.m4a', image_file: 'one_leg_tree_on_right.png')
-one_leg_tree_on_left = user.poses.create!(name: 'one_leg_tree_on_left', audio_file: 'one_leg_tree_on_left.m4a', image_file: 'one_leg_tree_on_left.png')
+one_leg_tree_on_right = user.poses.find_or_create_by(audio_file: 'one_leg_tree_on_right.m4a') { |pose| pose.name = 'one_leg_tree_on_right'; pose.image_file = 'one_leg_tree_on_right.png' }
+one_leg_tree_on_left = user.poses.find_or_create_by(audio_file: 'one_leg_tree_on_left.m4a') { |pose| pose.name = 'one_leg_tree_on_left'; pose.image_file = 'one_leg_tree_on_left.png' }
 
-left_foot_back_on_floor_namaste = user.poses.create!(name: 'left_foot_back_on_floor_namaste', audio_file: 'left_foot_back_on_floor_namaste.m4a', image_file: 'namaste.png')
-right_foot_back_on_floor_namaste = user.poses.create!(name: 'right_foot_back_on_floor_namaste', audio_file: 'right_foot_back_on_floor_namaste.m4a', image_file: 'namaste.png')
+left_foot_back_on_floor_namaste = user.poses.find_or_create_by(audio_file: 'left_foot_back_on_floor_namaste.m4a') { |pose| pose.name = 'left_foot_back_on_floor_namaste'; pose.image_file = 'namaste.png' }
+right_foot_back_on_floor_namaste = user.poses.find_or_create_by(audio_file: 'right_foot_back_on_floor_namaste.m4a') { |pose| pose.name = 'right_foot_back_on_floor_namaste'; pose.image_file = 'namaste.png' }
 
 Pose.all.each do |pose|
   new_name = pose.name.tr('_', ' ')
@@ -91,66 +91,64 @@ end
 
 
 puts 'Create Yoga Playlist'
-playlist = user.playlists.create!(name: '5 second yoga playlist', hold_time: 5)
-playlist.playlist_poses.create!([
-  { sequence_number: 1, pose_id: begin_at_head_of_yoga_mat.id },
-  { sequence_number: 2, pose_id: tree.id },
-  { sequence_number: 3, pose_id: dive_down_to_standing_fwd_bend.id },
-  { sequence_number: 4, pose_id: raise_up_to_flat_back.id },
-  { sequence_number: 5, pose_id: back_down_to_standing_fwd_bend.id },
-  { sequence_number: 6, pose_id: jump_back_to_plank.id },
-  { sequence_number: 7, pose_id: slowly_lower_to_chaturanga.id },
-  { sequence_number: 8, pose_id: down_to_floor_up_to_cobra.id },
-  { sequence_number: 9, pose_id: push_back_downward_dog_right_leg.id },
-  { sequence_number: 10, pose_id: swing_right_leg_runners_pose.id },
-  { sequence_number: 11, pose_id: arms_above_head_for_crescent_pose.id },
-  { sequence_number: 12, pose_id: swing_arm_back_warrior_2.id },
-  { sequence_number: 13, pose_id: lean_back_into_reverse_warrior.id },
-  { sequence_number: 14, pose_id: straighten_for_standing_reverse_warrior.id },
-  { sequence_number: 15, pose_id: triangle_pose_left_arm_up.id },
-  { sequence_number: 16, pose_id: reverse_warrior.id },
-  { sequence_number: 17, pose_id: warrior2.id },
-  { sequence_number: 18, pose_id: warrior1.id },
-  { sequence_number: 19, pose_id: runners_pose.id },
-  { sequence_number: 20, pose_id: collapse_into_pigeon.id },
-  { sequence_number: 21, pose_id: swing_right_leg_up_to_one_leg_downward_dog.id },
-  { sequence_number: 22, pose_id: leg_up_into_one_legged_chaturanga.id },
-  { sequence_number: 23, pose_id: push_up_to_upward_dog.id },
-  { sequence_number: 24, pose_id: side_plank_right_hand_down.id },
-  { sequence_number: 25, pose_id: down_to_downward_dog.id },
-  { sequence_number: 26, pose_id: jump_up_to_standing_fwd_bend.id },
-  { sequence_number: 27, pose_id: half_moon_pose_standing_on_right.id },
-  { sequence_number: 28, pose_id: come_back_down_to_standing_fwd_bend.id },
-  { sequence_number: 29, pose_id: one_leg_tree_on_right.id },
-  { sequence_number: 30, pose_id: left_foot_back_on_floor_namaste.id },
+playlist = user.playlists.find_or_create_by(name: 'flexibility playlist') { |pose| pose.hold_time = 5 }
+  playlist.playlist_poses.find_or_create_by(sequence_number: 1, pose_id: begin_at_head_of_yoga_mat.id)
+  playlist.playlist_poses.find_or_create_by(sequence_number: 2, pose_id: tree.id)
+  playlist.playlist_poses.find_or_create_by(sequence_number: 3, pose_id: dive_down_to_standing_fwd_bend.id)
+  playlist.playlist_poses.find_or_create_by(sequence_number: 4, pose_id: raise_up_to_flat_back.id)
+  playlist.playlist_poses.find_or_create_by(sequence_number: 5, pose_id: back_down_to_standing_fwd_bend.id)
+  playlist.playlist_poses.find_or_create_by(sequence_number: 6, pose_id: jump_back_to_plank.id)
+  playlist.playlist_poses.find_or_create_by(sequence_number: 7, pose_id: slowly_lower_to_chaturanga.id)
+  playlist.playlist_poses.find_or_create_by(sequence_number: 8, pose_id: down_to_floor_up_to_cobra.id)
+  playlist.playlist_poses.find_or_create_by(sequence_number: 9, pose_id: push_back_downward_dog_right_leg.id)
+  playlist.playlist_poses.find_or_create_by(sequence_number: 10, pose_id: swing_right_leg_runners_pose.id)
+  playlist.playlist_poses.find_or_create_by(sequence_number: 11, pose_id: arms_above_head_for_crescent_pose.id)
+  playlist.playlist_poses.find_or_create_by(sequence_number: 12, pose_id: swing_arm_back_warrior_2.id)
+  playlist.playlist_poses.find_or_create_by(sequence_number: 13, pose_id: lean_back_into_reverse_warrior.id)
+  playlist.playlist_poses.find_or_create_by(sequence_number: 14, pose_id: straighten_for_standing_reverse_warrior.id)
+  playlist.playlist_poses.find_or_create_by(sequence_number: 15, pose_id: triangle_pose_left_arm_up.id)
+  playlist.playlist_poses.find_or_create_by(sequence_number: 16, pose_id: reverse_warrior.id)
+  playlist.playlist_poses.find_or_create_by(sequence_number: 17, pose_id: warrior2.id)
+  playlist.playlist_poses.find_or_create_by(sequence_number: 18, pose_id: warrior1.id)
+  playlist.playlist_poses.find_or_create_by(sequence_number: 19, pose_id: runners_pose.id)
+  playlist.playlist_poses.find_or_create_by(sequence_number: 20, pose_id: collapse_into_pigeon.id)
+  playlist.playlist_poses.find_or_create_by(sequence_number: 21, pose_id: swing_right_leg_up_to_one_leg_downward_dog.id)
+  playlist.playlist_poses.find_or_create_by(sequence_number: 22, pose_id: leg_up_into_one_legged_chaturanga.id)
+  playlist.playlist_poses.find_or_create_by(sequence_number: 23, pose_id: push_up_to_upward_dog.id)
+  playlist.playlist_poses.find_or_create_by(sequence_number: 24, pose_id: side_plank_right_hand_down.id)
+  playlist.playlist_poses.find_or_create_by(sequence_number: 25, pose_id: down_to_downward_dog.id)
+  playlist.playlist_poses.find_or_create_by(sequence_number: 26, pose_id: jump_up_to_standing_fwd_bend.id)
+  playlist.playlist_poses.find_or_create_by(sequence_number: 27, pose_id: half_moon_pose_standing_on_right.id)
+  playlist.playlist_poses.find_or_create_by(sequence_number: 28, pose_id: come_back_down_to_standing_fwd_bend.id)
+  playlist.playlist_poses.find_or_create_by(sequence_number: 29, pose_id: one_leg_tree_on_right.id)
+  playlist.playlist_poses.find_or_create_by(sequence_number: 30, pose_id: left_foot_back_on_floor_namaste.id)
 
-  { sequence_number: 31, pose_id: tree.id },
-  { sequence_number: 32, pose_id: dive_down_to_standing_fwd_bend.id },
-  { sequence_number: 33, pose_id: raise_up_to_flat_back.id },
-  { sequence_number: 34, pose_id: back_down_to_standing_fwd_bend.id },
-  { sequence_number: 35, pose_id: jump_back_to_plank.id },
-  { sequence_number: 36, pose_id: slowly_lower_to_chaturanga.id },
-  { sequence_number: 37, pose_id: down_to_floor_up_to_cobra.id },
-  { sequence_number: 38, pose_id: push_back_downward_dog_left_leg.id },   #left
-  { sequence_number: 39, pose_id: swing_left_leg_runners_pose.id },   #left
-  { sequence_number: 40, pose_id: arms_above_head_for_crescent_pose.id },
-  { sequence_number: 41, pose_id: swing_arm_back_warrior_2.id },
-  { sequence_number: 42, pose_id: lean_back_into_reverse_warrior.id },
-  { sequence_number: 43, pose_id: straighten_for_standing_reverse_warrior.id },
-  { sequence_number: 44, pose_id: triangle_pose_right_arm_up.id },    #right
-  { sequence_number: 45, pose_id: reverse_warrior.id },
-  { sequence_number: 46, pose_id: warrior2.id },
-  { sequence_number: 47, pose_id: warrior1.id },
-  { sequence_number: 48, pose_id: runners_pose.id },
-  { sequence_number: 49, pose_id: collapse_into_pigeon.id },
-  { sequence_number: 50, pose_id: swing_left_leg_up_to_one_leg_downward_dog.id },   #left
-  { sequence_number: 51, pose_id: leg_up_into_one_legged_chaturanga.id },
-  { sequence_number: 52, pose_id: push_up_to_upward_dog.id },
-  { sequence_number: 53, pose_id: side_plank_left_hand_down.id },   #left
-  { sequence_number: 54, pose_id: down_to_downward_dog.id },
-  { sequence_number: 55, pose_id: jump_up_to_standing_fwd_bend.id },
-  { sequence_number: 56, pose_id: half_moon_pose_standing_on_left.id },   #left
-  { sequence_number: 57, pose_id: come_back_down_to_standing_fwd_bend.id },
-  { sequence_number: 58, pose_id: one_leg_tree_on_left.id },   #left
-  { sequence_number: 59, pose_id: right_foot_back_on_floor_namaste.id },    #right
-])
+  playlist.playlist_poses.find_or_create_by(sequence_number: 31, pose_id: tree.id)
+  playlist.playlist_poses.find_or_create_by(sequence_number: 32, pose_id: dive_down_to_standing_fwd_bend.id)
+  playlist.playlist_poses.find_or_create_by(sequence_number: 33, pose_id: raise_up_to_flat_back.id)
+  playlist.playlist_poses.find_or_create_by(sequence_number: 34, pose_id: back_down_to_standing_fwd_bend.id)
+  playlist.playlist_poses.find_or_create_by(sequence_number: 35, pose_id: jump_back_to_plank.id)
+  playlist.playlist_poses.find_or_create_by(sequence_number: 36, pose_id: slowly_lower_to_chaturanga.id)
+  playlist.playlist_poses.find_or_create_by(sequence_number: 37, pose_id: down_to_floor_up_to_cobra.id)
+  playlist.playlist_poses.find_or_create_by(sequence_number: 38, pose_id: push_back_downward_dog_left_leg.id) # left
+  playlist.playlist_poses.find_or_create_by(sequence_number: 39, pose_id: swing_left_leg_runners_pose.id) # left
+  playlist.playlist_poses.find_or_create_by(sequence_number: 40, pose_id: arms_above_head_for_crescent_pose.id)
+  playlist.playlist_poses.find_or_create_by(sequence_number: 41, pose_id: swing_arm_back_warrior_2.id)
+  playlist.playlist_poses.find_or_create_by(sequence_number: 42, pose_id: lean_back_into_reverse_warrior.id)
+  playlist.playlist_poses.find_or_create_by(sequence_number: 43, pose_id: straighten_for_standing_reverse_warrior.id)
+  playlist.playlist_poses.find_or_create_by(sequence_number: 44, pose_id: triangle_pose_right_arm_up.id) # right
+  playlist.playlist_poses.find_or_create_by(sequence_number: 45, pose_id: reverse_warrior.id)
+  playlist.playlist_poses.find_or_create_by(sequence_number: 46, pose_id: warrior2.id)
+  playlist.playlist_poses.find_or_create_by(sequence_number: 47, pose_id: warrior1.id)
+  playlist.playlist_poses.find_or_create_by(sequence_number: 48, pose_id: runners_pose.id)
+  playlist.playlist_poses.find_or_create_by(sequence_number: 49, pose_id: collapse_into_pigeon.id)
+  playlist.playlist_poses.find_or_create_by(sequence_number: 50, pose_id: swing_left_leg_up_to_one_leg_downward_dog.id) # left
+  playlist.playlist_poses.find_or_create_by(sequence_number: 51, pose_id: leg_up_into_one_legged_chaturanga.id)
+  playlist.playlist_poses.find_or_create_by(sequence_number: 52, pose_id: push_up_to_upward_dog.id)
+  playlist.playlist_poses.find_or_create_by(sequence_number: 53, pose_id: side_plank_left_hand_down.id) # left
+  playlist.playlist_poses.find_or_create_by(sequence_number: 54, pose_id: down_to_downward_dog.id)
+  playlist.playlist_poses.find_or_create_by(sequence_number: 55, pose_id: jump_up_to_standing_fwd_bend.id)
+  playlist.playlist_poses.find_or_create_by(sequence_number: 56, pose_id: half_moon_pose_standing_on_left.id) # left
+  playlist.playlist_poses.find_or_create_by(sequence_number: 57, pose_id: come_back_down_to_standing_fwd_bend.id)
+  playlist.playlist_poses.find_or_create_by(sequence_number: 58, pose_id: one_leg_tree_on_left.id) # left
+  playlist.playlist_poses.find_or_create_by(sequence_number: 59, pose_id: right_foot_back_on_floor_namaste.id) # right

--- a/lib/tasks/data_migrations.rake
+++ b/lib/tasks/data_migrations.rake
@@ -23,20 +23,14 @@ namespace :data do
     puts "Done!"
   end
 
-  desc "make all poses private"
+  desc "make admin poses private"
   task :private_poses => :environment do
-    Pose.all.each do |pose|
-      pose.update!(private: true)
+    public_poses = ['warrior1', 'warrior2', 'reverse warrior', 'standing forward bend', 'runners pose', 'triangle pose left arm up', 'triangle pose right arm up']
+    admin_poses = Pose.where.not(name: public_poses)
+
+    admin_poses.each do |pose|
+      pose.update!(admin_only: true)
     end
   end
-
-  desc "make all poses private"
-  task :reveal_some_poses => :environment do
-    poses = Pose.where(name: ['warrior1', 'warrior2', 'reverse warrior', 'standing forward bend', 'runners pose', 'triangle pose left arm up', 'triangle pose right arm up'])
-    poses.each do |pose|
-      pose.update!(private: false)
-    end
-  end
-
 
 end

--- a/lib/tasks/data_migrations.rake
+++ b/lib/tasks/data_migrations.rake
@@ -23,5 +23,20 @@ namespace :data do
     puts "Done!"
   end
 
+  desc "make all poses private"
+  task :private_poses => :environment do
+    Pose.all.each do |pose|
+      pose.update!(private: true)
+    end
+  end
+
+  desc "make all poses private"
+  task :reveal_some_poses => :environment do
+    poses = Pose.where(name: ['warrior1', 'warrior2', 'reverse warrior', 'standing forward bend', 'runners pose', 'triangle pose left arm up', 'triangle pose right arm up'])
+    poses.each do |pose|
+      pose.update!(private: false)
+    end
+  end
+
 
 end

--- a/spec/factories/pose.rb
+++ b/spec/factories/pose.rb
@@ -6,5 +6,6 @@ FactoryBot.define do
     sequence(:name) { |n| "pose#{n}" }
     sequence(:audio_file) { |n| "pose#{n}.wav" }
     sequence(:image_file) { |n| "pose#{n}.png" }
+    private { false }
   end
 end

--- a/spec/factories/pose.rb
+++ b/spec/factories/pose.rb
@@ -6,6 +6,6 @@ FactoryBot.define do
     sequence(:name) { |n| "pose#{n}" }
     sequence(:audio_file) { |n| "pose#{n}.wav" }
     sequence(:image_file) { |n| "pose#{n}.png" }
-    private { false }
+    admin_only { false }
   end
 end

--- a/spec/helpers/poses_helper_spec.rb
+++ b/spec/helpers/poses_helper_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PosesHelper, type: :helper do
+  describe 'form_poses' do
+    let(:private_pose) { create(:pose, admin_only: true) }
+    let(:public_pose) { create(:pose, admin_only: false) }
+
+    it 'returns publically accessbile poses for non-admin users' do
+      user = create(:user, admin: false)
+      expect(form_poses(user)).to include(public_pose)
+      expect(form_poses(user)).to_not include(private_pose)
+    end
+
+    it 'returns all poses for admin users' do
+      user = create(:user, admin: true)
+      expect(form_poses(user)).to include(public_pose)
+      expect(form_poses(user)).to include(private_pose)
+    end
+  end
+end

--- a/spec/models/pose_spec.rb
+++ b/spec/models/pose_spec.rb
@@ -14,4 +14,13 @@ RSpec.describe Pose, type: :model do
     it { should validate_presence_of(:audio_file) }
     it { should validate_presence_of(:image_file) }
   end
+  describe 'self.public' do
+    it 'returns only poses that are not marked as private' do
+      private_pose = create(:pose, private: true)
+      public_pose = create(:pose, private: false)
+
+      expect(Pose.public).to include(public_pose)
+      expect(Pose.public).to_not include(private_pose)
+    end
+  end
 end

--- a/spec/models/pose_spec.rb
+++ b/spec/models/pose_spec.rb
@@ -21,16 +21,17 @@ RSpec.describe Pose, type: :model do
       pose_a = create(:pose, name: 'A')
 
       expect(Pose.by_name.first).to eq(pose_a)
+      expect(Pose.by_name.last).to eq(pose_z)
     end
   end
 
-  describe 'self.public' do
-    it 'returns only poses that are not marked as private' do
-      private_pose = create(:pose, private: true)
-      public_pose = create(:pose, private: false)
+  describe 'self.public_poses' do
+    it 'returns only poses that are not marked as admin_only' do
+      private_pose = create(:pose, admin_only: true)
+      public_pose = create(:pose, admin_only: false)
 
-      expect(Pose.public).to include(public_pose)
-      expect(Pose.public).to_not include(private_pose)
+      expect(Pose.public_poses).to include(public_pose)
+      expect(Pose.public_poses).to_not include(private_pose)
     end
   end
 end

--- a/spec/models/pose_spec.rb
+++ b/spec/models/pose_spec.rb
@@ -14,6 +14,16 @@ RSpec.describe Pose, type: :model do
     it { should validate_presence_of(:audio_file) }
     it { should validate_presence_of(:image_file) }
   end
+
+  describe 'self.by_name' do
+    it 'orders poses alphabetically by name' do
+      pose_z = create(:pose, name: 'Z')
+      pose_a = create(:pose, name: 'A')
+
+      expect(Pose.by_name.first).to eq(pose_a)
+    end
+  end
+
   describe 'self.public' do
     it 'returns only poses that are not marked as private' do
       private_pose = create(:pose, private: true)


### PR DESCRIPTION
This PR removes the per-user constraint on poses. The idea is that the admin (me) provides a bunch of audio files and makes them available for all users to include in their playlists. Non-admin users no longer have the ability to edit poses at all. Admin users can see _all_ poses and have access to the pose admin area. 

After deploying the branch, will need to run a migration and move some poses into the private space. Do so by running:
```
heroku run rake db:migrate
heroku run rake data:private_poses
heroku restart
```

- Closes #36
- Closes #38 
- Closes #40
- Closes #42